### PR TITLE
JUCX: DESTDIR install prefix.

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -62,7 +62,7 @@ package:
 
 # Maven install phase
 install-data-hook: package
-	cp -fp $(java_build_dir)/jucx-@VERSION@.jar @libdir@
+	cp -fp $(java_build_dir)/jucx-@VERSION@.jar $(DESTDIR)@libdir@
 
 # Remove all compiled Java files
 clean-local:


### PR DESCRIPTION
## What
JUCX: DESTDIR install prefix.

## Why ?
To fix #4362
