### PR TITLE
JUCX: configure RPM with java by default.

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -13,7 +13,7 @@
 %bcond_with    rocm
 %bcond_with    ugni
 %bcond_with    xpmem
-%bcond_with    java
+%bcond_without java
 
 Name: ucx
 Version: @VERSION@


### PR DESCRIPTION
As mentioned in https://github.com/openucx/ucx/pull/4362